### PR TITLE
Task 6

### DIFF
--- a/project/cfg.py
+++ b/project/cfg.py
@@ -1,0 +1,32 @@
+from pathlib import Path
+from typing import Union
+from pyformlang.cfg.cfg import CFG, Variable
+
+
+def cfg_from_file(
+    file_path: Union[str, Path], start_symbol: Variable = Variable("S")
+) -> CFG:
+    with open(file_path, "r") as file:
+        return CFG.from_text(file.read(), start_symbol=start_symbol)
+
+
+def cfg_to_weakened_form_chomsky(cfg: CFG) -> CFG:
+    # unit production: S -> N ; N -> a
+    # eliminated unit production: S -> a
+    cfg_eliminated_unit_productions = (
+        cfg.remove_useless_symbols()
+        .eliminate_unit_productions()
+        .remove_useless_symbols()
+    )
+    # get_productions_with_only_single_terminals() is transforming all productions to looks like S -> ε or S -> a or S -> N1 .. Nn
+    new_productions = (
+        cfg_eliminated_unit_productions._get_productions_with_only_single_terminals()
+    )
+    # decompose_productions() is transforming productions with length more than 2 to productions with length 2
+    new_productions = cfg_eliminated_unit_productions._decompose_productions(
+        new_productions
+    )
+    return CFG(
+        start_symbol=cfg_eliminated_unit_productions._start_symbol,
+        productions=set(new_productions),
+    )

--- a/tests/test_cfg.py
+++ b/tests/test_cfg.py
@@ -1,0 +1,53 @@
+from project.cfg import cfg_from_file
+from project.cfg import cfg_to_weakened_form_chomsky
+from pyformlang.cfg.cfg import CFG, Variable, Terminal, Production, Epsilon
+
+
+def test_cfg_from_file(tmp_path):
+    actual_file_path = tmp_path / "actual_test_cfg.txt"
+    expected_cfg = CFG(
+        start_symbol=Variable("S"),
+        productions={
+            Production(
+                Variable("S"),
+                [Terminal("a"), Variable("S"), Terminal("b"), Variable("S")],
+            ),
+            Production(Variable("S"), [Epsilon()]),
+        },
+    )
+    with open(actual_file_path, "w") as file:
+        file.write("S -> a S b S | ε")
+    actual_cfg = cfg_from_file(actual_file_path)
+    assert all(
+        (
+            actual_cfg.start_symbol == expected_cfg.start_symbol,
+            actual_cfg.productions == expected_cfg.productions,
+        )
+    )
+
+
+def test_cfg_to_weakened_form_chomsky():
+    cfg = CFG.from_text(
+        """S -> a S b S | ε | N
+    N -> c
+    """
+    )
+    actual_cfg = cfg_to_weakened_form_chomsky(cfg)
+    expected_cfg = CFG(
+        start_symbol=Variable("S"),
+        productions={
+            Production(Variable("a#CNF#"), [Terminal("a")]),
+            Production(Variable("S"), [Variable("a#CNF#"), Variable("C#CNF#1")]),
+            Production(Variable("S"), [Epsilon()]),
+            Production(Variable("C#CNF#1"), [Variable("S"), Variable("C#CNF#2")]),
+            Production(Variable("b#CNF#"), [Terminal("b")]),
+            Production(Variable("C#CNF#2"), [Variable("b#CNF#"), Variable("S")]),
+            Production(Variable("S"), [Terminal("c")]),
+        },
+    )
+    assert all(
+        (
+            actual_cfg.start_symbol == expected_cfg.start_symbol,
+            actual_cfg.productions == expected_cfg.productions,
+        )
+    )


### PR DESCRIPTION
# Задача 6. Преобразование грамматики в ОНФХ

* **Мягкий дедлайн**: 17.10.2021, 23:59
* **Жёсткий дедлайн**: 20.10.2021, 23:59
* Полный балл: 2

## Определение ОНФХ

Контекстно-свободная грамматика находится в ослабленной нормальной форме Хомского (ОНФХ) тогда и только тогда, когда все её правила имеют следующий вид
1. ```A -> B C```
2. ```A -> a```
3. ```A -> eps```

, где ```A, B, C``` -- произвольные нетерминалы, ```a``` -- произвольный терминал, ```eps```--- обозначение для эпсилон.

Отличия от нормальной формы Хомского (НФХ).
1. Эпсилон может выводиться из любого нетерминала.
2. Стартовый нетерминал может встречаться в правых частях правил.


## Задача

- [x] Используя [возможности pyformlang для работы с контекстно-свободными грамматиками](https://pyformlang.readthedocs.io/en/latest/modules/context_free_grammar.html) реализовать **функцию** преобразования контекстно-свободной грамматики в ослабленную нормальную форму Хомского (ОНФХ), но не классическую нормальную форму Хомского (НФХ). НФХ является частным случаем ОНФХ, а значит можно утверждать, что грамматика, находящаяся в НФХ находится и в ОНФХ. Но в данной задаче нас интересует максимально слабая форма, то есть ОНФХ, но не НФХ.
- [x] Предусмотреть возможность чтения грамматики из файла. Формат файла определяется возможностями pyformalng. Например, можно использовать [эту функцию](https://pyformlang.readthedocs.io/en/latest/modules/context_free_grammar.html#pyformlang.cfg.CFG.from_text).
- [x] Добавить необходимые тесты.